### PR TITLE
Allow backers to redeem earnings without burning tokens by giving backers an NFT rather than an ERC20

### DIFF
--- a/crowdfund.sol
+++ b/crowdfund.sol
@@ -285,7 +285,6 @@ contract CrowdfundV2 is ERC721, ReentrancyGuard, IERC721TokenReceiver {
             valueWithdrawn: 0,
             shares: shares,
             });
-        updateShareValue();
         // Announce that funding has been closed.
         emit FundingClosed(address(this).balance, operatorTokens);
         // Transfer all funds to the operator.

--- a/crowdfund.sol
+++ b/crowdfund.sol
@@ -220,9 +220,6 @@ contract CrowdfundV2 is ERC721, ReentrancyGuard, IERC721TokenReceiver {
             ownerOf(backerToken) == msg.sender, 
             "Crowdfund: Only token owner can redeem"
         )
-        // update the share value, incase the contract
-        // has unexpectly received ETH
-        updateShareValue();
         // Check
         require(
             underlyingBalanceOf(backerToken) >= tokenAmount,
@@ -319,7 +316,14 @@ contract CrowdfundV2 is ERC721, ReentrancyGuard, IERC721TokenReceiver {
         // Accepting the bid will transfer WETH into this contract.
         unwrapWETH(bid.amount);
         // update share value
-        updateShareValue();
+        _shareValue = _shareValue
+            .add(
+                bid.amount
+                    .div(_totalShares)
+                    .sub(1)
+                    .div(SCALING_FACTOR)
+                    .add(1);
+                );
         // Annouce that the bid has been accepted, with the given amount.
         emit BidAccepted(bid.amount);
     }


### PR DESCRIPTION
(Caveat that this was written quickly and I am not even sure if it compiles--publish your repos with Hardhat/tests configured!!--but I believe the logic is sound. Also I do not expect this to be merged, just making a PR to share the idea.)

I believe the current crowd fund model is not optimal in that backers need to burn their tokens in order to claim gains. If they do this, they will miss out on future gains. If they do not do this, they will never realize any gains. 

This PR changes the crowd fund to give backers an NFT rather than ERC20s. Having unique IDs (via NFT) for each backer allows us to track how much they (the backerToken) are entitled to in total and how much they have redeemed so far. This is to allow backers to redeem earnings (from the Mirror media being bought and sold) without burning tokens. Specifically, the contract tracks how many shares the NFT (backerToken) holds, share to ETH conversion rate, and how much each backerToken has redeemed so far, so that they cannot claim more than their share. 

Much of this leverages this existing logic around the ERC20 tokens, and I've kept `token` names rather than `shares` for change simplicity. The difference is now that the NFT "owns" the shares rather than the address and share amounts are static.

As an added benefit, backers can track which backer number they are, which I believe has social value. 

Of course, this introduces a new downside, shares can only be bought and sold in batches via the backerNFTs. I believe this is acceptable, and maybe even preferable, but could also probably be overcome with some more engineering thought, e.g. perhaps a backer can at any time create a new backerToken and give it a portion of their shares. 